### PR TITLE
fix: invalid version for cmake

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,15 @@
 Source: dtkcrypt
 Section: libdevel
 Priority: optional
-Maintainer: Packages Builder <packages@deepin.com>
+Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends:
  debhelper-compat (= 12),
  cmake,
  librsvg2-dev,
- qtbase5-dev
+ qtbase5-dev,
+ doxygen,
+ graphviz,
+ qhelpgenerator-qt5
 Standards-Version: 4.5.0
 
 Package: libdtkcrypt

--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,12 @@
 include /usr/share/dpkg/default.mk
 export QT_SELECT = qt5
 
+PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
+# Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
+BUILD_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
+
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION=$(DEB_VERSION_UPSTREAM)
-
+	dh_auto_configure -- -DBUILD_VERSION=${BUILD_VER} -DVERSION=$(PACK_VER)


### PR DESCRIPTION
Handle invalid version like 1.0.0+u001 which can not be passed to cmake directly. Trim prefix like dtkcore.

Log: handle invalid version for cmake